### PR TITLE
Serialize runtime SQLite writes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,10 +31,8 @@ config :reencodarr, Reencodarr.Repo,
     temp_store: "MEMORY",
     # Enable full mutex mode for better concurrency
     locking_mode: "NORMAL",
-    # Allow reads during page writes
-    read_uncommitted: true,
-    # Increase busy timeout for concurrent operations (2 minutes)
-    busy_timeout: 120_000,
+    # Keep busy timeout modest now that writes are serialized in-process
+    busy_timeout: 5_000,
     # Large cache size (256MB) for better performance
     cache_size: -256_000,
     # Large memory mapping (512MB) for better I/O performance

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,8 +5,8 @@ config :reencodarr, Reencodarr.Repo,
   database: "priv/reencodarr_dev.db",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
-  # Increase pool size for better concurrency with Broadway pipelines
-  pool_size: 20,
+  # Keep the read pool modest; writes are serialized through DbWriter
+  pool_size: 5,
   # Increase checkout timeout for slow queries (especially JSON fragment queries in SQLite)
   timeout: 30_000,
   # DBConnection queue configuration for better handling under load

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,8 +34,8 @@ if config_env() == :prod do
 
   config :reencodarr, Reencodarr.Repo,
     database: database_path,
-    # Production pool size - can be overridden by DATABASE_POOL_SIZE env var
-    pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE") || "20")
+    # Keep the read pool modest; writes are serialized through DbWriter
+    pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE") || "5")
 
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/lib/reencodarr/ab_av1/crf_searcher.ex
+++ b/lib/reencodarr/ab_av1/crf_searcher.ex
@@ -17,6 +17,7 @@ defmodule Reencodarr.AbAv1.CrfSearcher do
   require Logger
 
   @max_buffered_lines 1024
+  @completed_without_subscriber_ttl_ms 100
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -129,7 +130,8 @@ defmodule Reencodarr.AbAv1.CrfSearcher do
            os_pid: os_pid,
            metadata: metadata,
            output_lines: [],
-           subscriber: nil
+           subscriber: nil,
+           pending_exit_status: nil
          }}
 
       {:error, reason} ->
@@ -144,6 +146,11 @@ defmodule Reencodarr.AbAv1.CrfSearcher do
     count = length(buffered)
     Enum.each(buffered, fn msg -> send(pid, msg) end)
     Logger.debug("CrfSearcher: subscribed #{inspect(pid)}, replayed #{count} lines")
+
+    if state.pending_exit_status do
+      Process.send_after(self(), :deliver_pending_exit_status, 0)
+    end
+
     {:reply, {:ok, count}, %{state | subscriber: pid}}
   end
 
@@ -158,6 +165,10 @@ defmodule Reencodarr.AbAv1.CrfSearcher do
   end
 
   @impl true
+  def handle_call(:kill, _from, %{port: :none} = state) do
+    {:stop, :normal, :ok, state}
+  end
+
   def handle_call(:kill, _from, state) do
     Logger.info("CrfSearcher: kill() called, killing OS process #{state.os_pid}")
     Helper.kill_os_process(state.os_pid)
@@ -170,15 +181,8 @@ defmodule Reencodarr.AbAv1.CrfSearcher do
   def handle_info({port, {:data, {:eol, line}}}, %{port: port} = state) do
     msg = {__MODULE__, {:line, line}}
 
-    new_lines =
-      if length(state.output_lines) < @max_buffered_lines do
-        [msg | state.output_lines]
-      else
-        [msg | Enum.take(state.output_lines, @max_buffered_lines - 1)]
-      end
-
     if state.subscriber, do: send(state.subscriber, msg)
-    {:noreply, %{state | output_lines: new_lines}}
+    {:noreply, buffer_output(state, msg)}
   end
 
   # noeol partial chunk — forward but do not buffer
@@ -194,8 +198,7 @@ defmodule Reencodarr.AbAv1.CrfSearcher do
   def handle_info({port, {:exit_status, code}}, %{port: port} = state) do
     Logger.info("CrfSearcher: port exited with status #{code}")
     msg = {__MODULE__, {:exit_status, code}}
-    if state.subscriber, do: send(state.subscriber, msg)
-    {:stop, :normal, state}
+    handle_port_exit_message(state, msg)
   end
 
   # Port closed / died without exit_status
@@ -203,14 +206,32 @@ defmodule Reencodarr.AbAv1.CrfSearcher do
   def handle_info({:EXIT, port, reason}, %{port: port} = state) do
     Logger.error("CrfSearcher: port died unexpectedly: #{inspect(reason)}")
     msg = {__MODULE__, {:exit_status, {:port_died, reason}}}
-    if state.subscriber, do: send(state.subscriber, msg)
-    {:stop, :normal, state}
+    handle_port_exit_message(state, msg)
   end
 
   # Normal port EXIT after exit_status already handled — ignore
   @impl true
   def handle_info({:EXIT, _port, :normal}, state) do
     {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:stop_completed_without_subscriber, %{subscriber: nil} = state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info(:stop_completed_without_subscriber, state) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:deliver_pending_exit_status, %{pending_exit_status: nil} = state) do
+    {:noreply, state}
+  end
+
+  def handle_info(:deliver_pending_exit_status, state) do
+    if state.subscriber, do: send(state.subscriber, state.pending_exit_status)
+    {:stop, :normal, %{state | pending_exit_status: nil}}
   end
 
   @impl true
@@ -233,5 +254,31 @@ defmodule Reencodarr.AbAv1.CrfSearcher do
     Logger.debug("CrfSearcher: terminating (#{inspect(reason)}), closing port")
     Helper.close_port(state.port)
     :ok
+  end
+
+  defp handle_port_exit_message(state, msg) do
+    if state.subscriber do
+      send(state.subscriber, msg)
+      {:stop, :normal, state}
+    else
+      Process.send_after(
+        self(),
+        :stop_completed_without_subscriber,
+        @completed_without_subscriber_ttl_ms
+      )
+
+      {:noreply, %{state | port: :none, os_pid: nil, pending_exit_status: msg}}
+    end
+  end
+
+  defp buffer_output(state, msg) do
+    new_lines =
+      if length(state.output_lines) < @max_buffered_lines do
+        [msg | state.output_lines]
+      else
+        [msg | Enum.take(state.output_lines, @max_buffered_lines - 1)]
+      end
+
+    %{state | output_lines: new_lines}
   end
 end

--- a/lib/reencodarr/application.ex
+++ b/lib/reencodarr/application.ex
@@ -56,12 +56,11 @@ defmodule Reencodarr.Application do
     base_children = [
       ReencodarrWeb.Telemetry,
       Reencodarr.Repo,
+      Reencodarr.DbWriter,
       {DNSCluster, query: Application.get_env(:reencodarr, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Reencodarr.PubSub},
       # Start the Finch HTTP client for sending emails
       {Finch, name: Reencodarr.Finch},
-      # Webhook processor GenServer - queues webhook tasks to prevent SQLite lock contention
-      ReencodarrWeb.WebhookProcessor,
       # Start to serve requests, typically the last entry
       ReencodarrWeb.Endpoint,
       # DynamicSupervisor for port-holder processes (AbAv1.Encoder, AbAv1.CrfSearcher).

--- a/lib/reencodarr/dashboard/state.ex
+++ b/lib/reencodarr/dashboard/state.ex
@@ -19,7 +19,7 @@ defmodule Reencodarr.Dashboard.State do
 
   @queue_refresh_interval 5_000
   @chart_refresh_interval 300_000
-  @default_queue_query_timeout 5_000
+  @default_queue_query_timeout 1_000
   @progress_debounce_ms 500
   @tracked_video_states [
     :needs_analysis,

--- a/lib/reencodarr/db_writer.ex
+++ b/lib/reencodarr/db_writer.ex
@@ -1,0 +1,137 @@
+defmodule Reencodarr.DbWriter do
+  @moduledoc """
+  Serializes runtime SQLite mutations through a single in-process writer.
+
+  Reads stay concurrent on the normal repo pool. Runtime writes should route
+  through this module so only one process is mutating SQLite at a time.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Reencodarr.Core.Retry
+  alias Reencodarr.Repo
+
+  @inline_envs [:test]
+  @default_call_timeout 60_000
+  @default_max_attempts 3
+  @default_backoff_ms 25
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec run((-> result), keyword()) :: result when result: var
+  def run(fun, opts \\ []) when is_function(fun, 0) do
+    if inline_mode?(opts) or in_writer?() do
+      execute_inline(fun, opts)
+    else
+      __MODULE__
+      |> GenServer.call(
+        {:run, fun, opts},
+        Keyword.get(opts, :writer_timeout, @default_call_timeout)
+      )
+      |> unwrap_result()
+    end
+  end
+
+  @spec transaction((-> result), keyword()) :: {:ok, result} | {:error, term()} when result: var
+  def transaction(fun, opts \\ []) when is_function(fun, 0) do
+    run(fn -> Repo.transaction(fun) end, opts)
+  end
+
+  @spec enqueue((-> any()), keyword()) :: :ok
+  def enqueue(fun, opts \\ []) when is_function(fun, 0) do
+    if inline_mode?(opts) or in_writer?() do
+      execute_enqueue(fun, opts)
+      :ok
+    else
+      GenServer.cast(__MODULE__, {:enqueue, fun, opts})
+    end
+  end
+
+  @spec in_writer?() :: boolean()
+  def in_writer?, do: Process.get(:db_writer_active, false) == true
+
+  @impl true
+  def init(_opts) do
+    {:ok, :ok}
+  end
+
+  @impl true
+  def handle_call({:run, fun, opts}, _from, state) do
+    {:reply, execute(fun, opts), state}
+  end
+
+  @impl true
+  def handle_cast({:enqueue, fun, opts}, state) do
+    execute_enqueue(fun, opts)
+
+    {:noreply, state}
+  end
+
+  defp inline_mode?(opts) do
+    Keyword.get(opts, :inline?, default_inline_mode?())
+  end
+
+  defp default_inline_mode? do
+    Application.get_env(:reencodarr, :env) in @inline_envs
+  end
+
+  defp execute_inline(fun, opts) do
+    execute(fun, opts)
+    |> unwrap_result()
+  end
+
+  defp execute_enqueue(fun, opts) do
+    case execute(fun, opts) do
+      {:ok, _result} ->
+        :ok
+
+      {:raised, kind, reason, stacktrace} ->
+        log_async_failure(kind, reason, stacktrace, opts)
+    end
+  end
+
+  defp execute(fun, opts) do
+    retry_opts = [
+      max_attempts: Keyword.get(opts, :max_attempts, @default_max_attempts),
+      base_backoff_ms: Keyword.get(opts, :base_backoff_ms, @default_backoff_ms),
+      label: Keyword.get(opts, :label)
+    ]
+
+    previous = Process.get(:db_writer_active)
+    Process.put(:db_writer_active, true)
+
+    try do
+      {:ok, Retry.retry_on_db_busy(fun, retry_opts)}
+    rescue
+      error ->
+        {:raised, :error, error, __STACKTRACE__}
+    catch
+      kind, reason ->
+        {:raised, kind, reason, __STACKTRACE__}
+    after
+      if previous == nil do
+        Process.delete(:db_writer_active)
+      else
+        Process.put(:db_writer_active, previous)
+      end
+    end
+  end
+
+  defp unwrap_result({:ok, value}), do: value
+
+  defp unwrap_result({:raised, kind, reason, stacktrace}) do
+    :erlang.raise(kind, reason, stacktrace)
+  end
+
+  defp log_async_failure(kind, reason, stacktrace, opts) do
+    label = Keyword.get(opts, :label, :db_writer)
+
+    Logger.error("""
+    DbWriter async task failed for #{inspect(label)}
+    #{Exception.format(kind, reason, stacktrace)}
+    """)
+  end
+end

--- a/lib/reencodarr/media.ex
+++ b/lib/reencodarr/media.ex
@@ -8,8 +8,8 @@ defmodule Reencodarr.Media do
   alias Reencodarr.AbAv1.{CrfSearch, Encode}
   alias Reencodarr.Analyzer.Broadway, as: AnalyzerBroadway
   alias Reencodarr.Core.Parsers
-  alias Reencodarr.Core.Retry
   alias Reencodarr.Dashboard.Events
+  alias Reencodarr.DbWriter
 
   alias Reencodarr.Media.{
     BadFileIssue,
@@ -29,6 +29,14 @@ defmodule Reencodarr.Media do
 
   @moduledoc "Handles media-related operations and database interactions."
   @queueable_states [:needs_analysis, :analyzed, :crf_searched]
+  @missing_file_scan_batch_size 50
+  @missing_file_delete_batch_size 25
+  @missing_file_check_concurrency 2
+  @missing_file_check_timeout_ms 2_000
+  @missing_file_batch_pause_ms 25
+
+  defp write(fun, opts) when is_function(fun, 0), do: DbWriter.run(fun, opts)
+  defp write_transaction(fun, opts) when is_function(fun, 0), do: DbWriter.transaction(fun, opts)
 
   # --- Video-related functions ---
   def list_videos, do: Repo.all(from v in Video, order_by: [desc: v.updated_at])
@@ -93,25 +101,18 @@ defmodule Reencodarr.Media do
     path = Map.get(attrs, :path) || Map.get(attrs, "path")
     old_video = if is_binary(path), do: fetch_dashboard_video_snapshot_by_path(path)
 
-    %Video{}
-    |> Video.changeset(attrs)
-    |> Repo.insert(
-      on_conflict: {:replace_all_except, [:id, :inserted_at, :updated_at]},
-      conflict_target: :path
-    )
-    |> tap(fn
-      {:ok, %Video{} = video} ->
-        action = if old_video, do: :update, else: :insert
-
-        broadcast_video_mutation(
-          action,
-          old_video,
-          fetch_dashboard_video_snapshot_by_id(video.id)
+    write(
+      fn ->
+        %Video{}
+        |> Video.changeset(attrs)
+        |> Repo.insert(
+          on_conflict: {:replace_all_except, [:id, :inserted_at, :updated_at]},
+          conflict_target: :path
         )
-
-      _ ->
-        :ok
-    end)
+        |> tap(&broadcast_upserted_video(&1, old_video))
+      end,
+      label: :media_upsert_video
+    )
   end
 
   def batch_upsert_videos(video_attrs_list) do
@@ -121,19 +122,24 @@ defmodule Reencodarr.Media do
   def update_video(%Video{} = video, attrs) do
     old_video = fetch_dashboard_video_snapshot_by_id(video.id) || dashboard_video_snapshot(video)
 
-    case video |> Video.changeset(attrs) |> Repo.update() do
-      {:ok, %Video{} = updated_video} ->
-        broadcast_video_mutation(
-          :update,
-          old_video,
-          fetch_dashboard_video_snapshot_by_id(updated_video.id)
-        )
+    write(
+      fn ->
+        case video |> Video.changeset(attrs) |> Repo.update() do
+          {:ok, %Video{} = updated_video} ->
+            broadcast_video_mutation(
+              :update,
+              old_video,
+              fetch_dashboard_video_snapshot_by_id(updated_video.id)
+            )
 
-        {:ok, updated_video}
+            {:ok, updated_video}
 
-      other ->
-        other
-    end
+          other ->
+            other
+        end
+      end,
+      label: :media_update_video
+    )
   end
 
   @doc """
@@ -146,26 +152,29 @@ defmodule Reencodarr.Media do
   def prioritize_videos(ids) when is_list(ids) do
     ordered_ids = ids |> Enum.uniq() |> Enum.reject(&is_nil/1)
 
-    Repo.transaction(fn ->
-      queueable_by_id =
-        from(v in Video,
-          where: v.id in ^ordered_ids and v.state in ^@queueable_states,
-          select: {v.id, v}
-        )
-        |> Repo.all()
-        |> Map.new()
+    write_transaction(
+      fn ->
+        queueable_by_id =
+          from(v in Video,
+            where: v.id in ^ordered_ids and v.state in ^@queueable_states,
+            select: {v.id, v}
+          )
+          |> Repo.all()
+          |> Map.new()
 
-      prioritized_ids =
-        ordered_ids
-        |> Enum.filter(&Map.has_key?(queueable_by_id, &1))
+        prioritized_ids =
+          ordered_ids
+          |> Enum.filter(&Map.has_key?(queueable_by_id, &1))
 
-      max_priority = highest_queue_priority()
-      total = length(prioritized_ids)
+        max_priority = highest_queue_priority()
+        total = length(prioritized_ids)
 
-      assign_priorities(prioritized_ids, queueable_by_id, max_priority, total)
+        assign_priorities(prioritized_ids, queueable_by_id, max_priority, total)
 
-      total
-    end)
+        total
+      end,
+      label: :media_prioritize_videos
+    )
     |> case do
       {:ok, count} -> {:ok, count}
       {:error, changeset} -> {:error, changeset}
@@ -179,14 +188,19 @@ defmodule Reencodarr.Media do
   def delete_video(%Video{} = video) do
     old_video = fetch_dashboard_video_snapshot_by_id(video.id) || dashboard_video_snapshot(video)
 
-    case Repo.delete(video) do
-      {:ok, deleted_video} ->
-        broadcast_video_mutation(:delete, old_video, nil)
-        {:ok, deleted_video}
+    write(
+      fn ->
+        case Repo.delete(video) do
+          {:ok, deleted_video} ->
+            broadcast_video_mutation(:delete, old_video, nil)
+            {:ok, deleted_video}
 
-      other ->
-        other
-    end
+          other ->
+            other
+        end
+      end,
+      label: :media_delete_video
+    )
   end
 
   def delete_video_with_vmafs(%Video{} = video) do
@@ -306,17 +320,22 @@ defmodule Reencodarr.Media do
       |> Map.put(:video_id, video.id)
       |> normalize_bad_file_issue_attrs()
 
-    case find_existing_unresolved_bad_file_issue(video.id, attrs) do
-      nil ->
-        %BadFileIssue{}
-        |> BadFileIssue.changeset(attrs)
-        |> Repo.insert()
+    write(
+      fn ->
+        case find_existing_unresolved_bad_file_issue(video.id, attrs) do
+          nil ->
+            %BadFileIssue{}
+            |> BadFileIssue.changeset(attrs)
+            |> Repo.insert()
 
-      existing ->
-        existing
-        |> BadFileIssue.changeset(attrs)
-        |> Repo.update()
-    end
+          existing ->
+            existing
+            |> BadFileIssue.changeset(attrs)
+            |> Repo.update()
+        end
+      end,
+      label: :media_create_bad_file_issue
+    )
   end
 
   @spec enqueue_bad_file_issue(BadFileIssue.t()) ::
@@ -342,9 +361,14 @@ defmodule Reencodarr.Media do
       %{status: status}
       |> maybe_put_bad_file_issue_timestamps(status)
 
-    issue
-    |> BadFileIssue.changeset(attrs)
-    |> Repo.update()
+    write(
+      fn ->
+        issue
+        |> BadFileIssue.changeset(attrs)
+        |> Repo.update()
+      end,
+      label: :media_update_bad_file_issue_status
+    )
   end
 
   @spec next_queued_bad_file_issue() :: BadFileIssue.t() | nil
@@ -579,15 +603,20 @@ defmodule Reencodarr.Media do
   Returns `{count, nil}` like `Repo.update_all/2`.
   """
   def mark_analyzed_av1_videos_as_encoded do
-    Repo.update_all(
-      from(v in Video,
-        where: v.state == :analyzed,
-        where:
-          fragment("? LIKE '%\"V_AV1\"%'", v.video_codecs) or
-            fragment("? LIKE '%\"AV1\"%'", v.video_codecs) or
-            fragment("LOWER(?) LIKE '%av1%'", v.path)
-      ),
-      set: [state: :encoded]
+    write(
+      fn ->
+        Repo.update_all(
+          from(v in Video,
+            where: v.state == :analyzed,
+            where:
+              fragment("? LIKE '%\"V_AV1\"%'", v.video_codecs) or
+                fragment("? LIKE '%\"AV1\"%'", v.video_codecs) or
+                fragment("LOWER(?) LIKE '%av1%'", v.path)
+          ),
+          set: [state: :encoded]
+        )
+      end,
+      label: :media_mark_analyzed_av1
     )
   end
 
@@ -639,12 +668,17 @@ defmodule Reencodarr.Media do
   def resolve_video_failures(video_id, opts \\ []) do
     now = DateTime.utc_now()
 
-    from(f in VideoFailure,
-      where: f.video_id == ^video_id and f.resolved == false,
-      update: [set: [resolved: true, resolved_at: ^now]]
+    write(
+      fn ->
+        from(f in VideoFailure,
+          where: f.video_id == ^video_id and f.resolved == false,
+          update: [set: [resolved: true, resolved_at: ^now]]
+        )
+        |> maybe_filter_failure_stage(opts[:stage])
+        |> Repo.update_all([])
+      end,
+      label: :media_resolve_video_failures
     )
-    |> maybe_filter_failure_stage(opts[:stage])
-    |> Repo.update_all([])
   end
 
   defp maybe_filter_failure_stage(query, nil), do: query
@@ -719,7 +753,7 @@ defmodule Reencodarr.Media do
     exclude_id = Encode.current_video_id()
 
     {with_vmaf, without_vmaf} =
-      Retry.retry_on_db_busy(
+      write(
         fn ->
           # Videos that have a chosen VMAF can safely go back to crf_searched for re-encoding.
           {with_vmaf, _} =
@@ -736,7 +770,7 @@ defmodule Reencodarr.Media do
 
           {with_vmaf, without_vmaf}
         end,
-        label: "reset orphaned encoding videos"
+        label: :media_reset_orphaned_encoding
       )
 
     total = with_vmaf + without_vmaf
@@ -770,11 +804,11 @@ defmodule Reencodarr.Media do
 
   defp reset_videos(query, log_message, target_state \\ :analyzed) do
     {count, _} =
-      Retry.retry_on_db_busy(
+      write(
         fn ->
           Repo.update_all(query, set: [state: target_state, updated_at: DateTime.utc_now()])
         end,
-        label: "reset videos to #{target_state}"
+        label: :media_reset_videos
       )
 
     if count > 0, do: Logger.info("Reset #{count} #{log_message}")
@@ -865,36 +899,39 @@ defmodule Reencodarr.Media do
   defp reset_problematic_videos(problematic_video_ids, videos_tested_count) do
     videos_reset_count = length(problematic_video_ids)
 
-    Repo.transaction(fn ->
-      # Delete VMAFs for these videos (they were generated with bad audio data)
-      {vmafs_deleted_count, _} =
-        from(v in Vmaf, where: v.video_id in ^problematic_video_ids)
-        |> Repo.delete_all()
+    write_transaction(
+      fn ->
+        # Delete VMAFs for these videos (they were generated with bad audio data)
+        {vmafs_deleted_count, _} =
+          from(v in Vmaf, where: v.video_id in ^problematic_video_ids)
+          |> Repo.delete_all()
 
-      # Reset analysis fields to force re-analysis
-      from(v in Video, where: v.id in ^problematic_video_ids)
-      |> Repo.update_all(
-        set: [
-          bitrate: nil,
-          video_codecs: nil,
-          audio_codecs: nil,
-          max_audio_channels: nil,
-          atmos: nil,
-          hdr: nil,
-          width: nil,
-          height: nil,
-          frame_rate: nil,
-          duration: nil,
-          updated_at: DateTime.utc_now()
-        ]
-      )
+        # Reset analysis fields to force re-analysis
+        from(v in Video, where: v.id in ^problematic_video_ids)
+        |> Repo.update_all(
+          set: [
+            bitrate: nil,
+            video_codecs: nil,
+            audio_codecs: nil,
+            max_audio_channels: nil,
+            atmos: nil,
+            hdr: nil,
+            width: nil,
+            height: nil,
+            frame_rate: nil,
+            duration: nil,
+            updated_at: DateTime.utc_now()
+          ]
+        )
 
-      %{
-        videos_tested: videos_tested_count,
-        videos_reset: videos_reset_count,
-        vmafs_deleted: vmafs_deleted_count
-      }
-    end)
+        %{
+          videos_tested: videos_tested_count,
+          videos_reset: videos_reset_count,
+          vmafs_deleted: vmafs_deleted_count
+        }
+      end,
+      label: :media_reset_problematic_videos
+    )
     |> case do
       {:ok, result} ->
         result
@@ -946,52 +983,55 @@ defmodule Reencodarr.Media do
           vmafs_deleted: integer()
         }
   def reset_videos_with_invalid_audio_metadata do
-    Repo.transaction(fn ->
-      # Find videos with problematic audio metadata that would cause Rules.audio/1 to return []
-      # This happens when max_audio_channels is nil/0 OR audio_codecs is nil/empty
-      # SQLite: audio_codecs is stored as JSON, check if empty with json_array_length
-      problematic_video_ids =
-        from(v in Video,
-          where:
-            v.state not in [:encoded, :failed] and
-              v.atmos != true and
-              (is_nil(v.max_audio_channels) or v.max_audio_channels == 0 or
-                 is_nil(v.audio_codecs) or
-                 fragment("json_array_length(?) = 0", v.audio_codecs)),
-          select: v.id
+    write_transaction(
+      fn ->
+        # Find videos with problematic audio metadata that would cause Rules.audio/1 to return []
+        # This happens when max_audio_channels is nil/0 OR audio_codecs is nil/empty
+        # SQLite: audio_codecs is stored as JSON, check if empty with json_array_length
+        problematic_video_ids =
+          from(v in Video,
+            where:
+              v.state not in [:encoded, :failed] and
+                v.atmos != true and
+                (is_nil(v.max_audio_channels) or v.max_audio_channels == 0 or
+                   is_nil(v.audio_codecs) or
+                   fragment("json_array_length(?) = 0", v.audio_codecs)),
+            select: v.id
+          )
+          |> Repo.all()
+
+        videos_reset_count = length(problematic_video_ids)
+
+        # Delete VMAFs for these videos (they were generated with bad audio data)
+        {vmafs_deleted_count, _} =
+          from(v in Vmaf, where: v.video_id in ^problematic_video_ids)
+          |> Repo.delete_all()
+
+        # Reset analysis fields to force re-analysis
+        from(v in Video, where: v.id in ^problematic_video_ids)
+        |> Repo.update_all(
+          set: [
+            bitrate: nil,
+            video_codecs: nil,
+            audio_codecs: nil,
+            max_audio_channels: nil,
+            atmos: nil,
+            hdr: nil,
+            width: nil,
+            height: nil,
+            frame_rate: nil,
+            duration: nil,
+            updated_at: DateTime.utc_now()
+          ]
         )
-        |> Repo.all()
 
-      videos_reset_count = length(problematic_video_ids)
-
-      # Delete VMAFs for these videos (they were generated with bad audio data)
-      {vmafs_deleted_count, _} =
-        from(v in Vmaf, where: v.video_id in ^problematic_video_ids)
-        |> Repo.delete_all()
-
-      # Reset analysis fields to force re-analysis
-      from(v in Video, where: v.id in ^problematic_video_ids)
-      |> Repo.update_all(
-        set: [
-          bitrate: nil,
-          video_codecs: nil,
-          audio_codecs: nil,
-          max_audio_channels: nil,
-          atmos: nil,
-          hdr: nil,
-          width: nil,
-          height: nil,
-          frame_rate: nil,
-          duration: nil,
-          updated_at: DateTime.utc_now()
-        ]
-      )
-
-      %{
-        videos_reset: videos_reset_count,
-        vmafs_deleted: vmafs_deleted_count
-      }
-    end)
+        %{
+          videos_reset: videos_reset_count,
+          vmafs_deleted: vmafs_deleted_count
+        }
+      end,
+      label: :media_reset_invalid_audio_metadata
+    )
     |> case do
       {:ok, result} -> result
       {:error, _reason} -> %{videos_reset: 0, vmafs_deleted: 0}
@@ -1014,42 +1054,40 @@ defmodule Reencodarr.Media do
           vmafs_deleted: integer()
         }
   def reset_all_failures do
-    Retry.retry_on_db_busy(
+    write_transaction(
       fn ->
-        Repo.transaction(fn ->
-          # First, get IDs and counts of videos that will be reset
-          failed_video_ids =
-            from(v in Video, where: v.state == :failed, select: v.id)
-            |> Repo.all()
+        # First, get IDs and counts of videos that will be reset
+        failed_video_ids =
+          from(v in Video, where: v.state == :failed, select: v.id)
+          |> Repo.all()
 
-          videos_to_reset_count = length(failed_video_ids)
+        videos_to_reset_count = length(failed_video_ids)
 
-          # Get count of failures that will be deleted
-          failures_to_delete_count =
-            from(f in VideoFailure, where: is_nil(f.resolved_at), select: count(f.id))
-            |> Repo.one()
+        # Get count of failures that will be deleted
+        failures_to_delete_count =
+          from(f in VideoFailure, where: is_nil(f.resolved_at), select: count(f.id))
+          |> Repo.one()
 
-          # Delete VMAFs for failed videos (they were likely generated with bad data)
-          {vmafs_deleted_count, _} =
-            from(v in Vmaf, where: v.video_id in ^failed_video_ids)
-            |> Repo.delete_all()
-
-          # Reset all failed videos back to needs_analysis
-          from(v in Video, where: v.state == :failed)
-          |> Repo.update_all(set: [state: :needs_analysis, updated_at: DateTime.utc_now()])
-
-          # Delete all unresolved failures
-          from(f in VideoFailure, where: is_nil(f.resolved_at))
+        # Delete VMAFs for failed videos (they were likely generated with bad data)
+        {vmafs_deleted_count, _} =
+          from(v in Vmaf, where: v.video_id in ^failed_video_ids)
           |> Repo.delete_all()
 
-          %{
-            videos_reset: videos_to_reset_count,
-            failures_deleted: failures_to_delete_count,
-            vmafs_deleted: vmafs_deleted_count
-          }
-        end)
+        # Reset all failed videos back to needs_analysis
+        from(v in Video, where: v.state == :failed)
+        |> Repo.update_all(set: [state: :needs_analysis, updated_at: DateTime.utc_now()])
+
+        # Delete all unresolved failures
+        from(f in VideoFailure, where: is_nil(f.resolved_at))
+        |> Repo.delete_all()
+
+        %{
+          videos_reset: videos_to_reset_count,
+          failures_deleted: failures_to_delete_count,
+          vmafs_deleted: vmafs_deleted_count
+        }
       end,
-      label: "reset all failures"
+      label: :media_reset_all_failures
     )
     |> case do
       {:ok, result} -> result
@@ -1114,22 +1152,32 @@ defmodule Reencodarr.Media do
     end
   end
 
-  def delete_videos_with_nonexistent_paths do
+  @doc """
+  Deletes videos whose files are confirmed missing.
+
+  Cleanup is intentionally throttled so it does not compete aggressively with
+  SQLite or remote filesystem I/O. Videos under unavailable library roots are
+  skipped instead of being treated as deleted files.
+  """
+  def delete_videos_with_nonexistent_paths(opts \\ []) do
     Logger.info("Starting cleanup of videos with nonexistent paths...")
 
-    deleted_count = delete_missing_files_batched(0, 0)
+    cleanup_opts = missing_file_cleanup_opts(opts)
+    log_unavailable_libraries(cleanup_opts.unavailable_libraries)
+
+    deleted_count = delete_missing_files_batched(0, 0, cleanup_opts)
 
     Logger.info("Cleanup complete: deleted #{deleted_count} videos with nonexistent paths")
     {:ok, deleted_count}
   end
 
-  defp delete_missing_files_batched(last_id, total_deleted) do
+  defp delete_missing_files_batched(last_id, total_deleted, cleanup_opts) do
     batch =
       from(v in Video,
         where: v.id > ^last_id,
         order_by: [asc: v.id],
-        limit: 500,
-        select: %{id: v.id, path: v.path}
+        limit: ^cleanup_opts.scan_batch_size,
+        select: %{id: v.id, path: v.path, library_id: v.library_id}
       )
       |> Repo.all()
 
@@ -1138,19 +1186,30 @@ defmodule Reencodarr.Media do
         total_deleted
 
       videos ->
-        missing_ids = find_missing_file_ids(videos)
-        new_total = delete_missing_batch(missing_ids, total_deleted, List.last(videos).id)
-        delete_missing_files_batched(List.last(videos).id, new_total)
+        last_video_id = List.last(videos).id
+        missing_ids = find_missing_file_ids(videos, cleanup_opts)
+
+        new_total =
+          missing_ids
+          |> Enum.chunk_every(cleanup_opts.delete_batch_size)
+          |> Enum.reduce(total_deleted, fn ids, acc ->
+            delete_missing_batch(ids, acc, last_video_id)
+          end)
+
+        pause_missing_file_cleanup(cleanup_opts)
+        delete_missing_files_batched(last_video_id, new_total, cleanup_opts)
     end
   end
 
-  defp find_missing_file_ids(videos) do
+  defp find_missing_file_ids(videos, cleanup_opts) do
     videos
+    |> Enum.filter(&library_available?(&1, cleanup_opts.available_library_ids))
     |> Task.async_stream(
       fn video -> {video.id, file_missing?(video)} end,
-      max_concurrency: 20,
-      timeout: 10_000,
-      on_timeout: :kill_task
+      max_concurrency: cleanup_opts.file_check_concurrency,
+      timeout: cleanup_opts.file_check_timeout_ms,
+      on_timeout: :kill_task,
+      ordered: false
     )
     |> Enum.flat_map(fn
       {:ok, {id, true}} -> [id]
@@ -1182,7 +1241,7 @@ defmodule Reencodarr.Media do
   end
 
   defp delete_videos_and_vmafs(video_ids) do
-    Retry.retry_on_db_busy(
+    write(
       fn ->
         Repo.transaction(fn ->
           {vmafs_deleted, _} =
@@ -1192,11 +1251,122 @@ defmodule Reencodarr.Media do
           %{vmafs_deleted: vmafs_deleted, videos_deleted: videos_deleted}
         end)
       end,
-      label: "delete videos and vmafs"
+      label: :media_delete_videos_and_vmafs
     )
   end
 
-  defp file_missing?(%{path: path}), do: not File.exists?(path)
+  defp missing_file_cleanup_opts(opts) do
+    libraries = Repo.all(from(l in Library, select: %{id: l.id, path: l.path}))
+
+    {available_library_ids, unavailable_libraries} =
+      Enum.reduce(libraries, {MapSet.new(), []}, fn library, {available, unavailable} ->
+        if library_root_available?(library.path) do
+          {MapSet.put(available, library.id), unavailable}
+        else
+          {available, [library | unavailable]}
+        end
+      end)
+
+    %{
+      scan_batch_size:
+        positive_cleanup_integer(
+          opts,
+          :scan_batch_size,
+          :missing_file_cleanup_scan_batch_size,
+          @missing_file_scan_batch_size
+        ),
+      delete_batch_size:
+        positive_cleanup_integer(
+          opts,
+          :delete_batch_size,
+          :missing_file_cleanup_delete_batch_size,
+          @missing_file_delete_batch_size
+        ),
+      file_check_concurrency:
+        positive_cleanup_integer(
+          opts,
+          :file_check_concurrency,
+          :missing_file_cleanup_file_check_concurrency,
+          @missing_file_check_concurrency
+        ),
+      file_check_timeout_ms:
+        positive_cleanup_integer(
+          opts,
+          :file_check_timeout_ms,
+          :missing_file_cleanup_file_check_timeout_ms,
+          @missing_file_check_timeout_ms
+        ),
+      batch_pause_ms:
+        non_negative_cleanup_integer(
+          opts,
+          :batch_pause_ms,
+          :missing_file_cleanup_batch_pause_ms,
+          @missing_file_batch_pause_ms
+        ),
+      available_library_ids: available_library_ids,
+      unavailable_libraries: Enum.reverse(unavailable_libraries)
+    }
+  end
+
+  defp positive_cleanup_integer(opts, opt_key, config_key, default) do
+    case Keyword.get(opts, opt_key, Application.get_env(:reencodarr, config_key, default)) do
+      value when is_integer(value) and value > 0 -> value
+      _invalid -> default
+    end
+  end
+
+  defp non_negative_cleanup_integer(opts, opt_key, config_key, default) do
+    case Keyword.get(opts, opt_key, Application.get_env(:reencodarr, config_key, default)) do
+      value when is_integer(value) and value >= 0 -> value
+      _invalid -> default
+    end
+  end
+
+  defp library_available?(%{library_id: nil}, _available_library_ids), do: true
+
+  defp library_available?(%{library_id: library_id}, available_library_ids) do
+    MapSet.member?(available_library_ids, library_id)
+  end
+
+  defp library_root_available?(path) when is_binary(path) do
+    case File.stat(path, time: :posix) do
+      {:ok, %File.Stat{type: :directory}} -> true
+      {:ok, _} -> false
+      {:error, _reason} -> false
+    end
+  end
+
+  defp library_root_available?(_path), do: false
+
+  defp log_unavailable_libraries([]), do: :ok
+
+  defp log_unavailable_libraries(libraries) do
+    paths = Enum.map_join(libraries, ", ", & &1.path)
+
+    Logger.warning(
+      "Skipping missing-path cleanup for #{length(libraries)} unavailable libraries: #{paths}"
+    )
+  end
+
+  defp pause_missing_file_cleanup(%{batch_pause_ms: 0}), do: :ok
+
+  defp pause_missing_file_cleanup(%{batch_pause_ms: batch_pause_ms}) do
+    Process.sleep(batch_pause_ms)
+  end
+
+  defp file_missing?(%{path: path}) do
+    case File.stat(path, time: :posix) do
+      {:ok, _stat} ->
+        false
+
+      {:error, reason} when reason in [:enoent, :enotdir] ->
+        true
+
+      {:error, reason} ->
+        Logger.debug("Skipping missing-path deletion for #{path}: #{inspect(reason)}")
+        false
+    end
+  end
 
   # --- Library-related functions ---
   def list_libraries do
@@ -1208,14 +1378,17 @@ defmodule Reencodarr.Media do
   end
 
   def create_library(attrs \\ %{}) do
-    %Library{} |> Library.changeset(attrs) |> Repo.insert()
+    write(fn -> %Library{} |> Library.changeset(attrs) |> Repo.insert() end,
+      label: :media_create_library
+    )
   end
 
   def update_library(%Library{} = l, attrs) do
-    l |> Library.changeset(attrs) |> Repo.update()
+    write(fn -> l |> Library.changeset(attrs) |> Repo.update() end, label: :media_update_library)
   end
 
-  def delete_library(%Library{} = l), do: Repo.delete(l)
+  def delete_library(%Library{} = l),
+    do: write(fn -> Repo.delete(l) end, label: :media_delete_library)
 
   def change_library(%Library{} = l, attrs \\ %{}) do
     Library.changeset(l, attrs)
@@ -1226,9 +1399,10 @@ defmodule Reencodarr.Media do
   def get_vmaf!(id), do: Repo.get!(Vmaf, id) |> Repo.preload(:video)
 
   def create_vmaf(attrs \\ %{}) do
-    %Vmaf{}
-    |> Vmaf.changeset(attrs)
-    |> Repo.insert()
+    write(
+      fn -> %Vmaf{} |> Vmaf.changeset(attrs) |> Repo.insert() end,
+      label: :media_create_vmaf
+    )
     |> tap(fn
       {:ok, %Vmaf{}} -> broadcast_vmaf_mutation(:insert, 1)
       _ -> :ok
@@ -1258,8 +1432,12 @@ defmodule Reencodarr.Media do
       existing_vmaf? = vmaf_conflict_exists?(changeset)
 
       result =
-        changeset
-        |> Repo.insert(Keyword.merge([conflict_target: [:crf, :video_id]], opts))
+        write(
+          fn ->
+            Repo.insert(changeset, Keyword.merge([conflict_target: [:crf, :video_id]], opts))
+          end,
+          label: :media_vmaf_operation
+        )
 
       handle_vmaf_insert_result(result, existing_vmaf?)
     else
@@ -1321,11 +1499,11 @@ defmodule Reencodarr.Media do
   defp calculate_vmaf_savings(_, _), do: nil
 
   def update_vmaf(%Vmaf{} = vmaf, attrs) do
-    vmaf |> Vmaf.changeset(attrs) |> Repo.update()
+    write(fn -> vmaf |> Vmaf.changeset(attrs) |> Repo.update() end, label: :media_update_vmaf)
   end
 
   def delete_vmaf(%Vmaf{} = vmaf) do
-    Repo.delete(vmaf)
+    write(fn -> Repo.delete(vmaf) end, label: :media_delete_vmaf)
     |> tap(fn
       {:ok, %Vmaf{}} -> broadcast_vmaf_mutation(:delete, 1)
       _ -> :ok
@@ -1346,8 +1524,13 @@ defmodule Reencodarr.Media do
       {3, nil}
   """
   def delete_vmafs_for_video(video_id) when is_integer(video_id) do
-    from(v in Vmaf, where: v.video_id == ^video_id)
-    |> Repo.delete_all()
+    write(
+      fn ->
+        from(v in Vmaf, where: v.video_id == ^video_id)
+        |> Repo.delete_all()
+      end,
+      label: :media_delete_vmafs_for_video
+    )
     |> tap(fn
       {count, _} when count > 0 -> broadcast_vmaf_mutation(:delete, count)
       _ -> :ok
@@ -1380,29 +1563,32 @@ defmodule Reencodarr.Media do
         {:error, "Video #{video_id} not found"}
 
       video ->
-        Repo.transaction(fn ->
-          # 1. Delete all VMAFs
-          delete_vmafs_for_video(video_id)
+        write_transaction(
+          fn ->
+            # 1. Delete all VMAFs
+            delete_vmafs_for_video(video_id)
 
-          # 2. Reset analysis fields to force re-analysis
-          update_video(video, %{
-            bitrate: nil,
-            video_codecs: nil,
-            audio_codecs: nil,
-            max_audio_channels: nil,
-            atmos: nil,
-            hdr: nil,
-            width: nil,
-            height: nil,
-            frame_rate: nil,
-            duration: nil
-          })
+            # 2. Reset analysis fields to force re-analysis
+            update_video(video, %{
+              bitrate: nil,
+              video_codecs: nil,
+              audio_codecs: nil,
+              max_audio_channels: nil,
+              atmos: nil,
+              hdr: nil,
+              width: nil,
+              height: nil,
+              frame_rate: nil,
+              duration: nil
+            })
 
-          # 3. Manually trigger analysis using Broadway dispatch
-          AnalyzerBroadway.dispatch_available()
+            # 3. Manually trigger analysis using Broadway dispatch
+            AnalyzerBroadway.dispatch_available()
 
-          video.path
-        end)
+            video.path
+          end,
+          label: :media_force_reanalyze_video
+        )
         |> case do
           {:ok, path} -> {:ok, path}
           {:error, reason} -> {:error, reason}
@@ -1606,8 +1792,13 @@ defmodule Reencodarr.Media do
         old_video = fetch_dashboard_video_snapshot_by_id(video_id)
 
         {1, _} =
-          from(v in Video, where: v.id == ^video_id)
-          |> Repo.update_all(set: [chosen_vmaf_id: vmaf_id, updated_at: DateTime.utc_now()])
+          write(
+            fn ->
+              from(v in Video, where: v.id == ^video_id)
+              |> Repo.update_all(set: [chosen_vmaf_id: vmaf_id, updated_at: DateTime.utc_now()])
+            end,
+            label: :media_mark_vmaf_as_chosen
+          )
 
         broadcast_video_mutation(
           :update,
@@ -1658,8 +1849,13 @@ defmodule Reencodarr.Media do
         old_video = fetch_dashboard_video_snapshot_by_id(video_id)
 
         {1, _} =
-          from(v in Video, where: v.id == ^video_id)
-          |> Repo.update_all(set: [chosen_vmaf_id: vmaf_id, updated_at: DateTime.utc_now()])
+          write(
+            fn ->
+              from(v in Video, where: v.id == ^video_id)
+              |> Repo.update_all(set: [chosen_vmaf_id: vmaf_id, updated_at: DateTime.utc_now()])
+            end,
+            label: :media_choose_best_vmaf
+          )
 
         broadcast_video_mutation(
           :update,
@@ -1812,16 +2008,19 @@ defmodule Reencodarr.Media do
   end
 
   def delete_unchosen_vmafs do
-    Repo.transaction(fn ->
-      # Get video_ids that have vmafs but none are chosen
-      video_ids_with_no_chosen_vmafs =
-        videos_with_no_chosen_vmafs_query()
-        |> Repo.all()
+    write_transaction(
+      fn ->
+        # Get video_ids that have vmafs but none are chosen
+        video_ids_with_no_chosen_vmafs =
+          videos_with_no_chosen_vmafs_query()
+          |> Repo.all()
 
-      # Delete all vmafs for those video_ids
-      from(v in Vmaf, where: v.video_id in ^video_ids_with_no_chosen_vmafs)
-      |> Repo.delete_all()
-    end)
+        # Delete all vmafs for those video_ids
+        from(v in Vmaf, where: v.video_id in ^video_ids_with_no_chosen_vmafs)
+        |> Repo.delete_all()
+      end,
+      label: :media_delete_unchosen_vmafs
+    )
     |> tap(fn
       {:ok, {count, _}} when count > 0 -> broadcast_vmaf_mutation(:delete, count)
       _ -> :ok
@@ -1835,11 +2034,16 @@ defmodule Reencodarr.Media do
   VMAFs will be deleted automatically when videos are re-analyzed and their properties change.
   """
   def reset_all_videos_for_reanalysis do
-    from(v in Video,
-      where: v.state not in [:encoded, :failed],
-      update: [set: [bitrate: nil]]
+    write(
+      fn ->
+        from(v in Video,
+          where: v.state not in [:encoded, :failed],
+          update: [set: [bitrate: nil]]
+        )
+        |> Repo.update_all([])
+      end,
+      label: :media_reset_all_videos_for_reanalysis
     )
-    |> Repo.update_all([])
   end
 
   @doc """
@@ -1857,17 +2061,7 @@ defmodule Reencodarr.Media do
           )
           |> Repo.all()
 
-        if batch_ids != [] do
-          {count, _} =
-            from(v in Video, where: v.id in ^batch_ids, update: [set: [bitrate: nil]])
-            |> Repo.update_all([])
-
-          Logger.info("Reset batch of #{count} videos for reanalysis")
-          Process.sleep(100)
-          {count, 0}
-        else
-          nil
-        end
+        next_reanalysis_batch(batch_ids)
       end)
       |> Enum.sum()
 
@@ -1875,15 +2069,49 @@ defmodule Reencodarr.Media do
     total
   end
 
+  defp broadcast_upserted_video({:ok, %Video{} = video}, old_video) do
+    action = if old_video, do: :update, else: :insert
+
+    broadcast_video_mutation(
+      action,
+      old_video,
+      fetch_dashboard_video_snapshot_by_id(video.id)
+    )
+  end
+
+  defp broadcast_upserted_video(_result, _old_video), do: :ok
+
+  defp next_reanalysis_batch([]), do: nil
+
+  defp next_reanalysis_batch(batch_ids) do
+    {count, _} =
+      write(
+        fn ->
+          from(v in Video, where: v.id in ^batch_ids, update: [set: [bitrate: nil]])
+          |> Repo.update_all([])
+        end,
+        label: :media_reset_videos_for_reanalysis_batch
+      )
+
+    Logger.info("Reset batch of #{count} videos for reanalysis")
+    Process.sleep(100)
+    {count, 0}
+  end
+
   @doc """
   Reset all failed videos to not failed in a single bulk operation.
   """
   def reset_failed_videos do
-    from(v in Video,
-      where: v.state == :failed,
-      update: [set: [state: :needs_analysis]]
+    write(
+      fn ->
+        from(v in Video,
+          where: v.state == :failed,
+          update: [set: [state: :needs_analysis]]
+        )
+        |> Repo.update_all([])
+      end,
+      label: :media_reset_failed_videos
     )
-    |> Repo.update_all([])
   end
 
   @doc """
@@ -1891,10 +2119,15 @@ defmodule Reencodarr.Media do
   This will force all videos to go through analysis again.
   """
   def reset_all_videos_to_needs_analysis do
-    from(v in Video,
-      update: [set: [state: :needs_analysis, bitrate: nil]]
+    write(
+      fn ->
+        from(v in Video,
+          update: [set: [state: :needs_analysis, bitrate: nil]]
+        )
+        |> Repo.update_all([])
+      end,
+      label: :media_reset_all_videos_to_needs_analysis
     )
-    |> Repo.update_all([])
   end
 
   @doc """

--- a/lib/reencodarr/media/video_failure.ex
+++ b/lib/reencodarr/media/video_failure.ex
@@ -144,20 +144,26 @@ defmodule Reencodarr.Media.VideoFailure do
       retry_count: retry_count
     }
 
-    DbWriter.run(fn ->
-      Reencodarr.Repo.insert(changeset(%__MODULE__{}, attrs))
-    end)
+    DbWriter.run(
+      fn ->
+        Reencodarr.Repo.insert(changeset(%__MODULE__{}, attrs))
+      end,
+      label: :video_failure_insert
+    )
   end
 
   @doc """
   Marks a failure as resolved.
   """
   def resolve_failure(%__MODULE__{} = failure) do
-    DbWriter.run(fn ->
-      failure
-      |> changeset(%{resolved: true, resolved_at: DateTime.utc_now()})
-      |> Reencodarr.Repo.update()
-    end)
+    DbWriter.run(
+      fn ->
+        failure
+        |> changeset(%{resolved: true, resolved_at: DateTime.utc_now()})
+        |> Reencodarr.Repo.update()
+      end,
+      label: :video_failure_resolve
+    )
   end
 
   @doc """

--- a/lib/reencodarr/media/video_failure.ex
+++ b/lib/reencodarr/media/video_failure.ex
@@ -2,6 +2,7 @@ defmodule Reencodarr.Media.VideoFailure do
   use Ecto.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
+  alias Reencodarr.DbWriter
   alias Reencodarr.Media.Video
 
   @moduledoc """
@@ -143,16 +144,20 @@ defmodule Reencodarr.Media.VideoFailure do
       retry_count: retry_count
     }
 
-    Reencodarr.Repo.insert(changeset(%__MODULE__{}, attrs))
+    DbWriter.run(fn ->
+      Reencodarr.Repo.insert(changeset(%__MODULE__{}, attrs))
+    end)
   end
 
   @doc """
   Marks a failure as resolved.
   """
   def resolve_failure(%__MODULE__{} = failure) do
-    failure
-    |> changeset(%{resolved: true, resolved_at: DateTime.utc_now()})
-    |> Reencodarr.Repo.update()
+    DbWriter.run(fn ->
+      failure
+      |> changeset(%{resolved: true, resolved_at: DateTime.utc_now()})
+      |> Reencodarr.Repo.update()
+    end)
   end
 
   @doc """

--- a/lib/reencodarr/media/video_queries.ex
+++ b/lib/reencodarr/media/video_queries.ex
@@ -7,7 +7,8 @@ defmodule Reencodarr.Media.VideoQueries do
   """
 
   import Ecto.Query
-  alias Reencodarr.{Media.Video, Media.Vmaf, Repo}
+  alias Reencodarr.{DbWriter, Media.Video, Media.Vmaf, Repo}
+  require Logger
 
   @doc """
   Gets videos ready for CRF search (state: analyzed).
@@ -103,28 +104,41 @@ defmodule Reencodarr.Media.VideoQueries do
   """
   @spec claim_videos_for_analysis(integer(), keyword()) :: [Video.t()]
   def claim_videos_for_analysis(limit, opts \\ []) do
-    candidates =
-      from(v in Video,
-        where: v.state == :needs_analysis,
-        order_by: [desc: v.priority, desc: v.size, desc: v.inserted_at],
-        limit: ^limit,
-        select: v.id
-      )
-      |> Repo.all(opts)
-
-    case candidates do
-      [] ->
-        []
-
-      ids ->
-        {_count, claimed} =
+    DbWriter.transaction(
+      fn ->
+        candidates =
           from(v in Video,
-            where: v.id in ^ids and v.state == :needs_analysis,
-            select: v
+            where: v.state == :needs_analysis,
+            order_by: [desc: v.priority, desc: v.size, desc: v.inserted_at],
+            limit: ^limit,
+            select: v.id
           )
-          |> Repo.update_all([set: [state: :analyzing, updated_at: DateTime.utc_now()]], opts)
+          |> Repo.all(opts)
 
+        case candidates do
+          [] ->
+            []
+
+          ids ->
+            {_count, claimed} =
+              from(v in Video,
+                where: v.id in ^ids and v.state == :needs_analysis,
+                select: v
+              )
+              |> Repo.update_all([set: [state: :analyzing, updated_at: DateTime.utc_now()]], opts)
+
+            claimed
+        end
+      end,
+      label: :video_queries_claim_videos_for_analysis
+    )
+    |> case do
+      {:ok, claimed} ->
         claimed
+
+      {:error, reason} ->
+        Logger.warning("Failed to claim videos for analysis: #{inspect(reason)}")
+        []
     end
   end
 
@@ -187,10 +201,8 @@ defmodule Reencodarr.Media.VideoQueries do
   def videos_ready_for_encoding_preview(limit, opts \\ []) do
     Repo.all(
       from(vid in Video,
-        join: v in Vmaf,
-        on: vid.chosen_vmaf_id == v.id,
-        where: vid.state == :crf_searched,
-        order_by: [desc: vid.priority, desc: v.savings, desc: vid.updated_at],
+        where: vid.state == :crf_searched and not is_nil(vid.chosen_vmaf_id),
+        order_by: [desc: vid.priority, desc: vid.updated_at],
         limit: ^limit,
         select: %{id: vid.id, path: vid.path}
       ),

--- a/lib/reencodarr/media/video_queries.ex
+++ b/lib/reencodarr/media/video_queries.ex
@@ -8,7 +8,6 @@ defmodule Reencodarr.Media.VideoQueries do
 
   import Ecto.Query
   alias Reencodarr.{DbWriter, Media.Video, Media.Vmaf, Repo}
-  require Logger
 
   @doc """
   Gets videos ready for CRF search (state: analyzed).
@@ -137,8 +136,7 @@ defmodule Reencodarr.Media.VideoQueries do
         claimed
 
       {:error, reason} ->
-        Logger.warning("Failed to claim videos for analysis: #{inspect(reason)}")
-        []
+        raise "Failed to claim videos for analysis: #{inspect(reason)}"
     end
   end
 

--- a/lib/reencodarr/media/video_queries.ex
+++ b/lib/reencodarr/media/video_queries.ex
@@ -201,8 +201,10 @@ defmodule Reencodarr.Media.VideoQueries do
   def videos_ready_for_encoding_preview(limit, opts \\ []) do
     Repo.all(
       from(vid in Video,
-        where: vid.state == :crf_searched and not is_nil(vid.chosen_vmaf_id),
-        order_by: [desc: vid.priority, desc: vid.updated_at],
+        join: v in Vmaf,
+        on: vid.chosen_vmaf_id == v.id,
+        where: vid.state == :crf_searched,
+        order_by: [desc: vid.priority, desc: v.savings, desc: vid.updated_at],
         limit: ^limit,
         select: %{id: vid.id, path: vid.path}
       ),

--- a/lib/reencodarr/media/video_state_machine.ex
+++ b/lib/reencodarr/media/video_state_machine.ex
@@ -24,7 +24,7 @@ defmodule Reencodarr.Media.VideoStateMachine do
   """
 
   import Ecto.Changeset
-  alias Reencodarr.Core.Retry
+  alias Reencodarr.DbWriter
   alias Reencodarr.Media.Video
   require Logger
 
@@ -370,8 +370,7 @@ defmodule Reencodarr.Media.VideoStateMachine do
     # Force :encoding so the :encoding → :encoded transition is always valid
     case transition_to_encoded(video) do
       {:ok, changeset} ->
-        Retry.retry_on_db_busy(
-          fn -> Reencodarr.Repo.update(changeset) end,
+        DbWriter.run(fn -> Reencodarr.Repo.update(changeset) end,
           label: "transition video to encoded"
         )
 
@@ -443,7 +442,8 @@ defmodule Reencodarr.Media.VideoStateMachine do
   defp do_repo_update(changeset, _opts) do
     target_state = Ecto.Changeset.get_field(changeset, :state)
     label = if target_state, do: "transition video to #{target_state}", else: "update video state"
-    Retry.retry_on_db_busy(fn -> Reencodarr.Repo.update(changeset) end, label: label)
+
+    DbWriter.run(fn -> Reencodarr.Repo.update(changeset) end, label: label)
   end
 
   # Check if video has low bitrate (less than 5 Mbps = 5,000,000 bps) AND is HDR and should skip encoding

--- a/lib/reencodarr/media/video_upsert.ex
+++ b/lib/reencodarr/media/video_upsert.ex
@@ -10,7 +10,7 @@ defmodule Reencodarr.Media.VideoUpsert do
   require Logger
   import Ecto.Query
   alias Reencodarr.Core.Retry
-  alias Reencodarr.{Media.Library, Media.Video, Media.VideoValidator, Media.Vmaf, Repo}
+  alias Reencodarr.{DbWriter, Media.Library, Media.Video, Media.VideoValidator, Media.Vmaf, Repo}
   alias Reencodarr.Media.VideoStateMachine
 
   @type attrs :: %{String.t() => any()} | %{atom() => any()}
@@ -21,6 +21,49 @@ defmodule Reencodarr.Media.VideoUpsert do
   """
   @spec upsert(attrs()) :: upsert_result()
   def upsert(attrs) do
+    DbWriter.transaction(
+      fn ->
+        case do_upsert(attrs) do
+          {:ok, video} ->
+            video
+
+          {:error, reason} ->
+            Repo.rollback(reason)
+        end
+      end,
+      label: "perform video upsert"
+    )
+    |> case do
+      {:ok, video} -> {:ok, video}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Batch upsert multiple videos using per-video transactions.
+  Returns a list of results, one for each video in the same order.
+  """
+  @spec batch_upsert([attrs()]) :: [upsert_result()]
+  def batch_upsert(video_attrs_list) when is_list(video_attrs_list) do
+    batch_upsert(video_attrs_list, [])
+  end
+
+  @spec batch_upsert([attrs()], keyword()) :: [upsert_result()]
+  def batch_upsert(video_attrs_list, opts) when is_list(video_attrs_list) and is_list(opts) do
+    writer_opts =
+      [label: :video_batch_upsert, max_attempts: 1]
+      |> Keyword.merge(opts)
+
+    DbWriter.run(
+      fn ->
+        Logger.debug("VideoUpsert batch processing #{length(video_attrs_list)} videos")
+        Enum.map(video_attrs_list, &process_single_video_in_batch/1)
+      end,
+      writer_opts
+    )
+  end
+
+  defp do_upsert(attrs) do
     Logger.debug("VideoUpsert processing: #{inspect(Map.get(attrs, "path"))}")
 
     normalized_attrs = attrs |> normalize_keys_to_strings() |> ensure_library_id()
@@ -34,22 +77,6 @@ defmodule Reencodarr.Media.VideoUpsert do
     |> insert_or_update_video(old_video)
   end
 
-  @doc """
-  Batch upsert multiple videos using per-video transactions.
-  Returns a list of results, one for each video in the same order.
-  """
-  @spec batch_upsert([attrs()]) :: [upsert_result()]
-  def batch_upsert(video_attrs_list) when is_list(video_attrs_list) do
-    Logger.debug("VideoUpsert batch processing #{length(video_attrs_list)} videos")
-
-    Enum.map(video_attrs_list, &process_single_video_in_batch/1)
-  end
-
-  # Retry transaction with exponential backoff for "Database busy" errors
-  defp retry_transaction(fun) do
-    Retry.retry_on_db_busy(fn -> Repo.transaction(fun) end, label: "video upsert transaction")
-  end
-
   @spec process_single_video_in_batch(attrs()) :: upsert_result()
   defp process_single_video_in_batch(attrs) do
     normalized_attrs =
@@ -61,11 +88,16 @@ defmodule Reencodarr.Media.VideoUpsert do
     old_video =
       Reencodarr.Media.fetch_dashboard_video_snapshot_by_path(Map.get(normalized_attrs, "path"))
 
-    retry_transaction(fn ->
-      normalized_attrs
-      |> handle_vmaf_deletion_and_bitrate_preservation()
-      |> perform_single_upsert_in_batch(old_video)
-    end)
+    Retry.retry_on_db_busy(
+      fn ->
+        Repo.transaction(fn ->
+          normalized_attrs
+          |> handle_vmaf_deletion_and_bitrate_preservation()
+          |> perform_single_upsert_in_batch(old_video)
+        end)
+      end,
+      label: "video upsert transaction"
+    )
     |> case do
       {:ok, result} ->
         result
@@ -212,7 +244,7 @@ defmodule Reencodarr.Media.VideoUpsert do
     on_conflict_query = build_on_conflict_query(attrs, conflict_except)
 
     attrs
-    |> perform_video_upsert_with_retry(on_conflict_query)
+    |> perform_video_upsert(on_conflict_query)
     |> handle_upsert_result(attrs, old_video)
   end
 
@@ -293,19 +325,6 @@ defmodule Reencodarr.Media.VideoUpsert do
         ) :: {:ok, Video.t()} | {:error, Ecto.Changeset.t()}
   defp perform_video_upsert(attrs, on_conflict_query) do
     do_insert(attrs, on_conflict_query)
-  end
-
-  @spec perform_video_upsert_with_retry(
-          %{String.t() => any()},
-          {:replace_all_except, [atom()]} | Ecto.Query.t()
-        ) :: {:ok, Video.t()} | {:error, Ecto.Changeset.t()}
-  defp perform_video_upsert_with_retry(attrs, on_conflict_query) do
-    Retry.retry_on_db_busy(
-      fn ->
-        perform_video_upsert(attrs, on_conflict_query)
-      end,
-      label: "perform video upsert"
-    )
   end
 
   @spec perform_single_upsert_in_batch(%{String.t() => any()}, map() | nil) ::

--- a/lib/reencodarr/services.ex
+++ b/lib/reencodarr/services.ex
@@ -2,6 +2,7 @@ defmodule Reencodarr.Services do
   @moduledoc """
   This module is responsible for communicating with external services.
   """
+  alias Reencodarr.DbWriter
   alias Reencodarr.Repo
   alias Reencodarr.Services.Config
   alias Reencodarr.Services.Radarr
@@ -79,9 +80,11 @@ defmodule Reencodarr.Services do
 
   """
   def create_config(attrs \\ %{}) do
-    %Config{}
-    |> Config.changeset(attrs)
-    |> Repo.insert()
+    DbWriter.run(fn ->
+      %Config{}
+      |> Config.changeset(attrs)
+      |> Repo.insert()
+    end)
   end
 
   @doc """
@@ -97,9 +100,11 @@ defmodule Reencodarr.Services do
 
   """
   def update_config(%Config{} = config, attrs) do
-    config
-    |> Config.changeset(attrs)
-    |> Repo.update()
+    DbWriter.run(fn ->
+      config
+      |> Config.changeset(attrs)
+      |> Repo.update()
+    end)
   end
 
   @doc """
@@ -115,7 +120,7 @@ defmodule Reencodarr.Services do
 
   """
   def delete_config(%Config{} = config) do
-    Repo.delete(config)
+    DbWriter.run(fn -> Repo.delete(config) end)
   end
 
   @doc """

--- a/lib/reencodarr/services.ex
+++ b/lib/reencodarr/services.ex
@@ -80,11 +80,14 @@ defmodule Reencodarr.Services do
 
   """
   def create_config(attrs \\ %{}) do
-    DbWriter.run(fn ->
-      %Config{}
-      |> Config.changeset(attrs)
-      |> Repo.insert()
-    end)
+    DbWriter.run(
+      fn ->
+        %Config{}
+        |> Config.changeset(attrs)
+        |> Repo.insert()
+      end,
+      label: :service_config_create
+    )
   end
 
   @doc """
@@ -100,11 +103,14 @@ defmodule Reencodarr.Services do
 
   """
   def update_config(%Config{} = config, attrs) do
-    DbWriter.run(fn ->
-      config
-      |> Config.changeset(attrs)
-      |> Repo.update()
-    end)
+    DbWriter.run(
+      fn ->
+        config
+        |> Config.changeset(attrs)
+        |> Repo.update()
+      end,
+      label: :service_config_update
+    )
   end
 
   @doc """
@@ -120,7 +126,7 @@ defmodule Reencodarr.Services do
 
   """
   def delete_config(%Config{} = config) do
-    DbWriter.run(fn -> Repo.delete(config) end)
+    DbWriter.run(fn -> Repo.delete(config) end, label: :service_config_delete)
   end
 
   @doc """

--- a/lib/reencodarr/sync.ex
+++ b/lib/reencodarr/sync.ex
@@ -11,9 +11,10 @@ defmodule Reencodarr.Sync do
   alias Reencodarr.Media.{MediaInfoExtractor, VideoFileInfo, VideoUpsert}
   alias Reencodarr.Media.Video.MediaInfoConverter
 
-  @default_batch_size 50
+  @default_batch_size 10
+  @default_write_batch_size 100
   @default_fetch_timeout_ms 90_000
-  @default_fetch_concurrency 8
+  @default_fetch_concurrency 2
   # Sync every 6 hours by default; override via :sync_interval_ms app env
   @default_sync_interval_ms :timer.hours(6)
 
@@ -34,12 +35,13 @@ defmodule Reencodarr.Sync do
   end
 
   def handle_cast(action, state) when action in [:sync_episodes, :sync_movies] do
-    {get_items, get_files, service_type} = resolve_action(action)
+    sync_config = resolve_action(action)
+    service_type = sync_config.service_type
 
     Events.broadcast_event(:sync_started, %{service_type: service_type})
 
     try do
-      sync_items(get_items, get_files, service_type)
+      sync_items(sync_config)
     rescue
       e ->
         Logger.error("Sync #{service_type} crashed: #{Exception.message(e)}")
@@ -68,12 +70,24 @@ defmodule Reencodarr.Sync do
 
   # Private Functions
   defp resolve_action(:sync_episodes),
-    do: {&Services.get_shows/0, &Services.get_episode_files/1, :sonarr}
+    do: %{
+      get_items: &Services.get_shows/0,
+      get_files: &Services.get_episode_files/1,
+      service_type: :sonarr
+    }
 
   defp resolve_action(:sync_movies),
-    do: {&Services.get_movies/0, &Services.get_movie_files/1, :radarr}
+    do: %{
+      get_items: &Services.get_movies/0,
+      get_files: &Services.get_movie_files/1,
+      service_type: :radarr
+    }
 
-  defp sync_items(get_items, get_files, service_type) do
+  defp sync_items(%{
+         get_items: get_items,
+         get_files: get_files,
+         service_type: service_type
+       }) do
     case get_items.() do
       {:ok, %Req.Response{body: items}} when is_list(items) ->
         process_items_in_batches(items, get_files, service_type)
@@ -84,63 +98,112 @@ defmodule Reencodarr.Sync do
   end
 
   defp process_items_in_batches(items, get_files, service_type) do
+    total_items = length(items)
+    library_mappings = preload_library_mappings()
+
     items
     |> Stream.chunk_every(sync_batch_size())
     |> Stream.with_index()
-    |> Stream.each(&process_batch(&1, get_files, service_type, length(items)))
+    |> Stream.each(&process_batch(&1, get_files, service_type, total_items, library_mappings))
     |> Stream.run()
   end
 
-  defp process_batch({batch, batch_index}, get_files, service_type, total_items) do
+  defp process_batch({batch, batch_index}, get_files, service_type, total_items, library_mappings) do
     batch_start_time = System.monotonic_time(:millisecond)
 
-    # Collect all files from all items in this batch
-    all_files =
-      batch
-      |> Task.async_stream(&fetch_and_upsert_files(&1["id"], get_files, service_type),
+    stats =
+      Task.Supervisor.async_stream_nolink(
+        Reencodarr.TaskSupervisor,
+        batch,
+        &fetch_item_files(&1, get_files),
         max_concurrency: sync_fetch_concurrency(),
         timeout: sync_fetch_timeout_ms(),
-        on_timeout: :kill_task
+        on_timeout: :kill_task,
+        ordered: false
       )
-      |> Enum.flat_map(fn
-        {:ok, files} when is_list(files) ->
-          files
-
-        {:error, reason} ->
-          Logger.warning("Sync: Task failed in batch #{batch_index}: #{inspect(reason)}")
-          []
-
-        _ ->
-          []
+      |> Enum.reduce(%{items_processed: 0, files_seen: 0, files_written: 0}, fn result, acc ->
+        process_item_fetch_result(result, service_type, library_mappings, batch_index, acc)
       end)
 
-    # Process all files in a single batch operation
-    files_processed =
-      if Enum.empty?(all_files) do
-        0
-      else
-        batch_upsert_videos(all_files, service_type)
-        length(all_files)
-      end
-
-    # Log batch performance metrics
     batch_duration = System.monotonic_time(:millisecond) - batch_start_time
 
     Logger.info(
-      "Sync: Batch #{batch_index} processed #{files_processed} files in #{batch_duration}ms"
+      "Sync: Batch #{batch_index} processed #{stats.items_processed} items, " <>
+        "saw #{stats.files_seen} files, wrote #{stats.files_written} files in #{batch_duration}ms"
     )
 
-    # Update progress
-    progress = div((batch_index + 1) * sync_batch_size() * 100, total_items)
-
     Events.broadcast_event(:sync_progress, %{
-      progress: min(progress, 100),
+      progress: progress_percent(batch_index, sync_batch_size(), total_items),
       service_type: service_type
     })
   end
 
+  defp process_item_fetch_result(
+         {:ok, {:ok, item_id, files}},
+         service_type,
+         library_mappings,
+         _batch_index,
+         acc
+       ) do
+    files_written = write_item_files(files, service_type, library_mappings)
+
+    Logger.info(
+      "Sync: Item #{inspect(item_id)} fetched #{length(files)} files, wrote #{files_written} files"
+    )
+
+    %{
+      items_processed: acc.items_processed + 1,
+      files_seen: acc.files_seen + length(files),
+      files_written: acc.files_written + files_written
+    }
+  end
+
+  defp process_item_fetch_result(
+         {:ok, {:error, item_id, reason}},
+         _service_type,
+         _library_mappings,
+         _batch_index,
+         acc
+       ) do
+    Logger.warning("Sync: Failed to fetch files for item #{inspect(item_id)}: #{inspect(reason)}")
+    %{acc | items_processed: acc.items_processed + 1}
+  end
+
+  defp process_item_fetch_result(
+         {:exit, reason},
+         _service_type,
+         _library_mappings,
+         batch_index,
+         acc
+       ) do
+    Logger.warning("Sync: Task failed in batch #{batch_index}: #{inspect(reason)}")
+    %{acc | items_processed: acc.items_processed + 1}
+  end
+
+  defp write_item_files([], _service_type, _library_mappings), do: 0
+
+  defp write_item_files(files, service_type, library_mappings) do
+    files
+    |> Enum.chunk_every(sync_write_batch_size())
+    |> Enum.reduce(0, fn chunk, written ->
+      written + batch_upsert_videos(chunk, service_type, library_mappings)
+    end)
+  end
+
   defp sync_batch_size do
     Application.get_env(:reencodarr, :sync_batch_size, @default_batch_size)
+  end
+
+  defp sync_write_batch_size do
+    Application.get_env(:reencodarr, :sync_write_batch_size) ||
+      Application.get_env(:reencodarr, :sync_file_batch_size, @default_write_batch_size)
+  end
+
+  defp progress_percent(_batch_index, _batch_size, 0), do: 100
+
+  defp progress_percent(batch_index, batch_size, total_count) do
+    processed_count = min((batch_index + 1) * batch_size, total_count)
+    div(processed_count * 100, total_count)
   end
 
   defp sync_fetch_timeout_ms do
@@ -157,6 +220,12 @@ defmodule Reencodarr.Sync do
   """
   def batch_upsert_videos(files, service_type) do
     library_mappings = preload_library_mappings()
+
+    batch_upsert_videos(files, service_type, library_mappings)
+    :ok
+  end
+
+  defp batch_upsert_videos(files, service_type, library_mappings) do
     file_refs = extract_file_refs(files)
 
     # Pre-filter: only look up rows for paths in this batch instead of loading the
@@ -181,7 +250,7 @@ defmodule Reencodarr.Sync do
       Logger.info("Sync: Processing #{length(video_attrs_list)} changed videos in batch")
       perform_batch_transaction(video_attrs_list)
     else
-      :ok
+      0
     end
   end
 
@@ -232,7 +301,7 @@ defmodule Reencodarr.Sync do
       Logger.info("Sync: Successfully processed #{success_count} videos")
     end
 
-    :ok
+    success_count
   end
 
   defp preload_library_mappings do
@@ -301,17 +370,27 @@ defmodule Reencodarr.Sync do
     end
   end
 
-  defp fetch_and_upsert_files(id, get_files, _service_type) do
+  defp fetch_item_files(item, get_files) do
+    id = item_id(item)
+
     case get_files.(id) do
       {:ok, %Req.Response{body: files}} when is_list(files) ->
-        # Collect all files for batch processing instead of individual upserts
-        files
+        {:ok, id, files}
 
-      _ ->
-        Logger.error("Fetch files error for id #{inspect(id)}")
-        []
+      response ->
+        {:error, id, response}
     end
+  rescue
+    error ->
+      {:error, item_id(item), Exception.message(error)}
+  catch
+    kind, reason ->
+      {:error, item_id(item), {kind, reason}}
   end
+
+  defp item_id(%{"id" => id}), do: id
+  defp item_id(%{id: id}), do: id
+  defp item_id(_), do: nil
 
   # Keep these functions for individual file processing (used by webhooks)
   def upsert_video_from_file(%VideoFileInfo{size: nil} = file, service_type) do
@@ -335,13 +414,8 @@ defmodule Reencodarr.Sync do
     # Check if video exists and file size hasn't changed
     existing_video = Media.get_video_by_path(info.path)
 
-    result =
-      Repo.transaction(fn ->
-        handle_video_upsert(existing_video, info)
-      end)
-
     # VideoUpsert will automatically set state to needs_analysis for zero bitrate
-    result
+    {:ok, handle_video_upsert(existing_video, info)}
   end
 
   defp handle_video_upsert({:ok, video}, info) do
@@ -424,22 +498,18 @@ defmodule Reencodarr.Sync do
     # Convert directly to MediaInfo format
     mediainfo = MediaInfoConverter.from_service_file(file, service_type)
 
-    # Store in database
-    result =
-      Repo.transaction(fn ->
-        VideoUpsert.upsert(%{
-          "path" => file["path"],
-          "size" => file["size"],
-          "service_id" => to_string(file["id"]),
-          "service_type" => to_string(service_type),
-          "mediainfo" => mediainfo,
-          "bitrate" => file["overallBitrate"] || 0,
-          "dateAdded" => file["dateAdded"]
-        })
-      end)
-
-    # VideoUpsert will automatically set state to needs_analysis for missing bitrate
-    result
+    # Store in database.
+    # VideoUpsert will automatically set state to needs_analysis for missing bitrate.
+    {:ok,
+     VideoUpsert.upsert(%{
+       "path" => file["path"],
+       "size" => file["size"],
+       "service_id" => to_string(file["id"]),
+       "service_type" => to_string(service_type),
+       "mediainfo" => mediainfo,
+       "bitrate" => file["overallBitrate"] || 0,
+       "dateAdded" => file["dateAdded"]
+     })}
   end
 
   defp build_video_file_info(file, _media_info, service_type) do

--- a/lib/reencodarr/sync.ex
+++ b/lib/reencodarr/sync.ex
@@ -500,16 +500,15 @@ defmodule Reencodarr.Sync do
 
     # Store in database.
     # VideoUpsert will automatically set state to needs_analysis for missing bitrate.
-    {:ok,
-     VideoUpsert.upsert(%{
-       "path" => file["path"],
-       "size" => file["size"],
-       "service_id" => to_string(file["id"]),
-       "service_type" => to_string(service_type),
-       "mediainfo" => mediainfo,
-       "bitrate" => file["overallBitrate"] || 0,
-       "dateAdded" => file["dateAdded"]
-     })}
+    VideoUpsert.upsert(%{
+      "path" => file["path"],
+      "size" => file["size"],
+      "service_id" => to_string(file["id"]),
+      "service_type" => to_string(service_type),
+      "mediainfo" => mediainfo,
+      "bitrate" => file["overallBitrate"] || 0,
+      "dateAdded" => file["dateAdded"]
+    })
   end
 
   defp build_video_file_info(file, _media_info, service_type) do

--- a/lib/reencodarr_web/webhook_processor.ex
+++ b/lib/reencodarr_web/webhook_processor.ex
@@ -1,42 +1,15 @@
 defmodule ReencodarrWeb.WebhookProcessor do
   @moduledoc """
-  GenServer that processes webhook tasks sequentially to prevent SQLite lock contention.
-
-  Webhooks queue their work via cast, avoiding Task.start which floods SQLite with
-  concurrent writes. The GenServer processes one task at a time with retry logic.
-
-  In test environment, tasks are executed synchronously in the calling process to avoid
-  database sandbox issues.
+  Routes webhook-triggered work through the global DbWriter.
   """
 
-  use GenServer
-  require Logger
-
-  alias Reencodarr.Core.Retry
-
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
-  end
+  alias Reencodarr.DbWriter
 
   def queue(fun) when is_function(fun, 0) do
     process(fun)
   end
 
-  if Application.compile_env(:reencodarr, :env) == :test do
-    def process(fun) when is_function(fun, 0) do
-      # In test, execute synchronously to avoid sandbox connection issues
-      # We need explicit try/catch to catch :exit signals from OTP processes
-      Retry.retry_on_db_busy(fun, label: "webhook task")
-    catch
-      :exit, reason ->
-        Logger.error("Webhook processor task failed: #{inspect(reason)}")
-    end
-  else
-    def process(fun) when is_function(fun, 0) do
-      # In production, queue via GenServer for sequential processing
-      GenServer.cast(__MODULE__, {:process, fun})
-    end
-  end
+  def process(fun) when is_function(fun, 0), do: DbWriter.enqueue(fun, label: :webhook)
 
   def reconcile_waiting_bad_file_issues(
         {:ok, {:ok, %Reencodarr.Media.Video{} = video}},
@@ -51,49 +24,5 @@ defmodule ReencodarrWeb.WebhookProcessor do
 
   def reconcile_waiting_bad_file_issues(other_result, _service_type) do
     other_result
-  end
-
-  @impl true
-  def init(_opts) do
-    {:ok, []}
-  end
-
-  @impl true
-  def handle_cast({:process, fun}, []) do
-    # Process immediately if queue is empty
-    execute_task(fun)
-
-    {:noreply, []}
-  end
-
-  @impl true
-  def handle_cast({:process, fun}, state) do
-    # Queue if already processing
-    {:noreply, [fun | state]}
-  end
-
-  @impl true
-  def handle_info({:EXIT, _pid, _reason}, [fun | rest]) do
-    # Process next item when current one completes
-    execute_task(fun)
-    {:noreply, rest}
-  end
-
-  @impl true
-  def handle_info({:EXIT, _pid, _reason}, []) do
-    # No more items to process
-    {:noreply, []}
-  end
-
-  defp execute_task(fun) do
-    # Spawn a linked process for async sequential execution
-    spawn_link(fn ->
-      try do
-        Retry.retry_on_db_busy(fun, label: "webhook task")
-      catch
-        :exit, reason ->
-          Logger.error("Webhook processor task failed: #{inspect(reason)}")
-      end
-    end)
   end
 end

--- a/test/reencodarr/dashboard/state_test.exs
+++ b/test/reencodarr/dashboard/state_test.exs
@@ -111,6 +111,8 @@ defmodule Reencodarr.Dashboard.StateTest do
 
   describe "video change events" do
     test "updates incremental stats and queue counts from video mutation broadcasts" do
+      State.get_state()
+
       {:ok, video} =
         Fixtures.video_fixture(%{
           path: "/test/video_change_counter.mkv",
@@ -940,6 +942,8 @@ defmodule Reencodarr.Dashboard.StateTest do
 
   describe "incremental stats updates" do
     test "video mutations update queue_counts without a stats refresh query" do
+      State.get_state()
+
       insert_video()
       :timer.sleep(50)
 
@@ -970,6 +974,8 @@ defmodule Reencodarr.Dashboard.StateTest do
     end
 
     test "vmaf and chosen-vmaf mutations update totals without a stats refresh query" do
+      State.get_state()
+
       video = insert_video()
       vmaf = insert_vmaf(video)
       :timer.sleep(50)

--- a/test/reencodarr/db_writer_test.exs
+++ b/test/reencodarr/db_writer_test.exs
@@ -1,0 +1,134 @@
+defmodule Reencodarr.DbWriterTest do
+  use Reencodarr.DataCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Reencodarr.DbWriter
+
+  test "run executes inline in test and returns the function result" do
+    refute DbWriter.in_writer?()
+
+    result =
+      DbWriter.run(fn ->
+        assert DbWriter.in_writer?()
+        :ok
+      end)
+
+    assert result == :ok
+    refute DbWriter.in_writer?()
+  end
+
+  test "nested run executes inline without deadlocking" do
+    assert :nested =
+             DbWriter.run(fn ->
+               assert DbWriter.in_writer?()
+
+               DbWriter.run(fn ->
+                 assert DbWriter.in_writer?()
+                 :nested
+               end)
+             end)
+  end
+
+  test "enqueue executes immediately in test" do
+    test_pid = self()
+
+    assert :ok =
+             DbWriter.enqueue(fn ->
+               send(test_pid, :enqueued)
+             end)
+
+    assert_receive :enqueued
+  end
+
+  test "inline enqueue logs failures without crashing the caller" do
+    log =
+      capture_log(fn ->
+        assert :ok =
+                 DbWriter.enqueue(
+                   fn ->
+                     raise "boom"
+                   end,
+                   label: :inline_failing_job
+                 )
+      end)
+
+    assert log =~ "DbWriter async task failed for :inline_failing_job"
+    assert log =~ "RuntimeError"
+    assert log =~ "boom"
+  end
+
+  test "transaction preserves Repo.transaction semantics" do
+    assert {:ok, :committed} =
+             DbWriter.transaction(fn ->
+               :committed
+             end)
+
+    assert {:error, :rolled_back} =
+             DbWriter.transaction(fn ->
+               Repo.rollback(:rolled_back)
+             end)
+  end
+
+  test "run uses writer_timeout without consuming Repo timeout options" do
+    test_pid = self()
+
+    task =
+      Task.async(fn ->
+        DbWriter.run(
+          fn ->
+            send(test_pid, :writer_entered)
+
+            receive do
+              :release_writer -> :occupied
+            end
+          end,
+          inline?: false,
+          writer_timeout: 1_000
+        )
+      end)
+
+    assert_receive :writer_entered
+
+    available_task =
+      Task.async(fn ->
+        DbWriter.run(
+          fn -> :available end,
+          inline?: false,
+          timeout: 1,
+          writer_timeout: 1_000
+        )
+      end)
+
+    send(Process.whereis(DbWriter), :release_writer)
+
+    assert Task.await(available_task) == :available
+    assert Task.await(task) == :occupied
+  end
+
+  test "enqueue logs async failures with the writer label" do
+    log =
+      capture_log(fn ->
+        assert :ok =
+                 DbWriter.enqueue(
+                   fn ->
+                     raise "boom"
+                   end,
+                   inline?: false,
+                   label: :failing_job
+                 )
+
+        assert :barrier =
+                 DbWriter.run(
+                   fn ->
+                     :barrier
+                   end,
+                   inline?: false
+                 )
+      end)
+
+    assert log =~ "DbWriter async task failed for :failing_job"
+    assert log =~ "RuntimeError"
+    assert log =~ "boom"
+  end
+end

--- a/test/reencodarr/media/delete_busy_test.exs
+++ b/test/reencodarr/media/delete_busy_test.exs
@@ -7,6 +7,45 @@ defmodule Reencodarr.Media.DeleteBusyTest do
   alias Reencodarr.Media.{Video, Vmaf}
   alias Reencodarr.Repo
 
+  test "delete_videos_with_nonexistent_paths/1 deletes missing videos under available libraries" do
+    library_path = Path.join(System.tmp_dir!(), "library_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(library_path)
+    on_exit(fn -> File.rm_rf(library_path) end)
+
+    library = Fixtures.library_fixture(%{path: library_path})
+    missing_path = Path.join(library_path, "missing.mkv")
+    {:ok, video} = Fixtures.video_fixture(%{path: missing_path, library_id: library.id})
+
+    assert {:ok, 1} =
+             Media.delete_videos_with_nonexistent_paths(
+               scan_batch_size: 1,
+               delete_batch_size: 1,
+               file_check_concurrency: 1,
+               batch_pause_ms: 0
+             )
+
+    assert Repo.get(Video, video.id) == nil
+  end
+
+  test "delete_videos_with_nonexistent_paths/1 skips videos when the library root is unavailable" do
+    library_path =
+      Path.join(System.tmp_dir!(), "missing_library_#{System.unique_integer([:positive])}")
+
+    library = Fixtures.library_fixture(%{path: library_path})
+    missing_path = Path.join(library_path, "missing.mkv")
+    {:ok, video} = Fixtures.video_fixture(%{path: missing_path, library_id: library.id})
+
+    assert {:ok, 0} =
+             Media.delete_videos_with_nonexistent_paths(
+               scan_batch_size: 1,
+               delete_batch_size: 1,
+               file_check_concurrency: 1,
+               batch_pause_ms: 0
+             )
+
+    assert Repo.get(Video, video.id) != nil
+  end
+
   test "delete_videos_with_nonexistent_paths/0 uses the database busy retry wrapper" do
     :meck.new(Retry, [:passthrough])
 
@@ -26,7 +65,7 @@ defmodule Reencodarr.Media.DeleteBusyTest do
 
     :meck.expect(Retry, :retry_on_db_busy, fn fun, opts ->
       send(self(), :retry_on_db_busy_called)
-      assert opts[:label] == "delete videos and vmafs"
+      assert opts[:label] == :media_delete_videos_and_vmafs
       fun.()
     end)
 

--- a/test/reencodarr/media/video_queries_test.exs
+++ b/test/reencodarr/media/video_queries_test.exs
@@ -474,5 +474,19 @@ defmodule Reencodarr.Media.VideoQueriesTest do
       assert preview.path == video.path
       assert Map.keys(preview) |> Enum.sort() == [:id, :path]
     end
+
+    test "excludes crf_searched videos without a chosen VMAF" do
+      {:ok, video} =
+        Fixtures.video_fixture(%{
+          path: "/test/encoding_preview_without_chosen_vmaf.mkv",
+          state: :crf_searched,
+          video_codecs: ["h264"],
+          audio_codecs: ["aac"]
+        })
+
+      previews = VideoQueries.videos_ready_for_encoding_preview(100)
+
+      refute Enum.any?(previews, &(&1.id == video.id))
+    end
   end
 end

--- a/test/reencodarr/sync_orchestration_test.exs
+++ b/test/reencodarr/sync_orchestration_test.exs
@@ -1,0 +1,301 @@
+defmodule Reencodarr.SyncOrchestrationTest do
+  use Reencodarr.DataCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Reencodarr.{Media, Sync}
+
+  @sync_env_keys [
+    :sync_batch_size,
+    :sync_write_batch_size,
+    :sync_file_batch_size,
+    :sync_fetch_concurrency,
+    :sync_fetch_timeout_ms
+  ]
+
+  setup do
+    old_env = Map.new(@sync_env_keys, &{&1, Application.get_env(:reencodarr, &1, :unset)})
+    Enum.each(@sync_env_keys, &Application.delete_env(:reencodarr, &1))
+
+    :meck.unload()
+
+    on_exit(fn ->
+      restore_env(old_env)
+      :meck.unload()
+    end)
+
+    library = Fixtures.library_fixture(%{path: "/test"})
+    %{library: library}
+  end
+
+  describe "sync_episodes orchestration" do
+    test "fetches shows, fetches files per show, and creates videos" do
+      test_pid = self()
+
+      refute function_exported?(Reencodarr.Services, :get_all_episode_files, 0)
+
+      mock_analyzer_dispatch(test_pid)
+      :meck.new(Reencodarr.Services, [:passthrough])
+
+      :meck.expect(Reencodarr.Services, :get_shows, fn ->
+        send(test_pid, :shows_called)
+        {:ok, %Req.Response{status: 200, body: [%{"id" => 1}, %{"id" => 2}]}}
+      end)
+
+      :meck.expect(Reencodarr.Services, :get_episode_files, fn series_id ->
+        send(test_pid, {:per_series_called, series_id})
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: [service_file("/test/shows/series_#{series_id}.mkv", series_id)]
+         }}
+      end)
+
+      capture_log(fn ->
+        assert {:noreply, %{}} = Sync.handle_cast(:sync_episodes, %{})
+      end)
+
+      assert_received :shows_called
+      assert_received {:per_series_called, 1}
+      assert_received {:per_series_called, 2}
+      assert_received :analyzer_dispatched
+
+      assert {:ok, _video} = Media.get_video_by_path("/test/shows/series_1.mkv")
+      assert {:ok, _video} = Media.get_video_by_path("/test/shows/series_2.mkv")
+    end
+
+    test "writes one item response in bounded chunks" do
+      test_pid = self()
+      Application.put_env(:reencodarr, :sync_write_batch_size, 2)
+
+      files =
+        for id <- 1..5 do
+          service_file("/test/bounded/episode_#{id}.mkv", id)
+        end
+
+      mock_analyzer_dispatch(test_pid)
+      :meck.new(Reencodarr.Services, [:passthrough])
+
+      :meck.expect(Reencodarr.Services, :get_shows, fn ->
+        {:ok, %Req.Response{status: 200, body: [%{"id" => 10}]}}
+      end)
+
+      :meck.expect(Reencodarr.Services, :get_episode_files, fn 10 ->
+        {:ok, %Req.Response{status: 200, body: files}}
+      end)
+
+      log =
+        capture_info_log(fn ->
+          assert {:noreply, %{}} = Sync.handle_cast(:sync_episodes, %{})
+        end)
+
+      assert log =~ "Item 10 fetched 5 files, wrote 5 files"
+
+      for file <- files do
+        assert {:ok, _video} = Media.get_video_by_path(file["path"])
+      end
+    end
+
+    test "processes each completed item response without a combined all-files write" do
+      test_pid = self()
+      Application.put_env(:reencodarr, :sync_write_batch_size, 10)
+
+      mock_analyzer_dispatch(test_pid)
+      :meck.new(Reencodarr.Services, [:passthrough])
+
+      :meck.expect(Reencodarr.Services, :get_shows, fn ->
+        {:ok, %Req.Response{status: 200, body: [%{"id" => 1}, %{"id" => 2}]}}
+      end)
+
+      :meck.expect(Reencodarr.Services, :get_episode_files, fn
+        1 ->
+          {:ok,
+           %Req.Response{
+             status: 200,
+             body: [
+               service_file("/test/per_item/episode_1a.mkv", 101),
+               service_file("/test/per_item/episode_1b.mkv", 102)
+             ]
+           }}
+
+        2 ->
+          {:ok,
+           %Req.Response{
+             status: 200,
+             body: [service_file("/test/per_item/episode_2a.mkv", 201)]
+           }}
+      end)
+
+      log =
+        capture_info_log(fn ->
+          assert {:noreply, %{}} = Sync.handle_cast(:sync_episodes, %{})
+        end)
+
+      assert log =~ "Item 1 fetched 2 files, wrote 2 files"
+      assert log =~ "Item 2 fetched 1 files, wrote 1 files"
+      assert log =~ "saw 3 files, wrote 3 files"
+
+      assert {:ok, _video} = Media.get_video_by_path("/test/per_item/episode_1a.mkv")
+      assert {:ok, _video} = Media.get_video_by_path("/test/per_item/episode_2a.mkv")
+    end
+
+    test "logs a failed item fetch and continues with the remaining items" do
+      test_pid = self()
+
+      mock_analyzer_dispatch(test_pid)
+      :meck.new(Reencodarr.Services, [:passthrough])
+
+      :meck.expect(Reencodarr.Services, :get_shows, fn ->
+        {:ok, %Req.Response{status: 200, body: [%{"id" => 1}, %{"id" => 2}]}}
+      end)
+
+      :meck.expect(Reencodarr.Services, :get_episode_files, fn
+        1 ->
+          {:error, :timeout}
+
+        2 ->
+          {:ok,
+           %Req.Response{
+             status: 200,
+             body: [service_file("/test/continues/episode_2.mkv", 2)]
+           }}
+      end)
+
+      log =
+        capture_info_log(fn ->
+          assert {:noreply, %{}} = Sync.handle_cast(:sync_episodes, %{})
+        end)
+
+      assert log =~ "Failed to fetch files for item 1"
+      assert log =~ "Item 2 fetched 1 files, wrote 1 files"
+      assert {:ok, _video} = Media.get_video_by_path("/test/continues/episode_2.mkv")
+    end
+
+    test "empty item file list does not write and does not fail" do
+      test_pid = self()
+
+      mock_analyzer_dispatch(test_pid)
+      :meck.new(Reencodarr.Services, [:passthrough])
+
+      :meck.expect(Reencodarr.Services, :get_shows, fn ->
+        {:ok, %Req.Response{status: 200, body: [%{"id" => 1}]}}
+      end)
+
+      :meck.expect(Reencodarr.Services, :get_episode_files, fn 1 ->
+        {:ok, %Req.Response{status: 200, body: []}}
+      end)
+
+      log =
+        capture_info_log(fn ->
+          assert {:noreply, %{}} = Sync.handle_cast(:sync_episodes, %{})
+        end)
+
+      assert log =~ "Item 1 fetched 0 files, wrote 0 files"
+      refute log =~ "Processing 0 changed videos"
+      assert Media.count_videos() == 0
+      assert_received :analyzer_dispatched
+    end
+  end
+
+  describe "sync_movies orchestration" do
+    test "fetches movies, fetches files per movie, and creates videos" do
+      test_pid = self()
+
+      refute function_exported?(Reencodarr.Services, :get_all_movie_files, 0)
+
+      mock_analyzer_dispatch(test_pid)
+      :meck.new(Reencodarr.Services, [:passthrough])
+
+      :meck.expect(Reencodarr.Services, :get_movies, fn ->
+        send(test_pid, :movies_called)
+        {:ok, %Req.Response{status: 200, body: [%{"id" => 3}, %{"id" => 4}]}}
+      end)
+
+      :meck.expect(Reencodarr.Services, :get_movie_files, fn movie_id ->
+        send(test_pid, {:per_movie_called, movie_id})
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: [service_file("/test/movies/movie_#{movie_id}.mkv", movie_id)]
+         }}
+      end)
+
+      capture_log(fn ->
+        assert {:noreply, %{}} = Sync.handle_cast(:sync_movies, %{})
+      end)
+
+      assert_received :movies_called
+      assert_received {:per_movie_called, 3}
+      assert_received {:per_movie_called, 4}
+      assert_received :analyzer_dispatched
+
+      assert {:ok, _video} = Media.get_video_by_path("/test/movies/movie_3.mkv")
+      assert {:ok, _video} = Media.get_video_by_path("/test/movies/movie_4.mkv")
+    end
+
+    test "analyzer dispatch runs once after sync completion" do
+      test_pid = self()
+
+      mock_analyzer_dispatch(test_pid)
+      :meck.new(Reencodarr.Services, [:passthrough])
+
+      :meck.expect(Reencodarr.Services, :get_movies, fn ->
+        {:ok, %Req.Response{status: 200, body: [%{"id" => 3}]}}
+      end)
+
+      :meck.expect(Reencodarr.Services, :get_movie_files, fn 3 ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: [service_file("/test/analyzer/movie_3.mkv", 3)]
+         }}
+      end)
+
+      capture_log(fn ->
+        assert {:noreply, %{}} = Sync.handle_cast(:sync_movies, %{})
+      end)
+
+      assert_received :analyzer_dispatched
+      assert :meck.num_calls(Reencodarr.Analyzer.Broadway, :dispatch_available, []) == 1
+    end
+  end
+
+  defp mock_analyzer_dispatch(test_pid) do
+    :meck.new(Reencodarr.Analyzer.Broadway, [:passthrough])
+
+    :meck.expect(Reencodarr.Analyzer.Broadway, :dispatch_available, fn ->
+      send(test_pid, :analyzer_dispatched)
+      :ok
+    end)
+  end
+
+  defp capture_info_log(fun) do
+    previous_level = Logger.level()
+    Logger.configure(level: :info)
+
+    try do
+      capture_log(fun)
+    after
+      Logger.configure(level: previous_level)
+    end
+  end
+
+  defp restore_env(old_env) do
+    Enum.each(old_env, fn
+      {key, :unset} -> Application.delete_env(:reencodarr, key)
+      {key, value} -> Application.put_env(:reencodarr, key, value)
+    end)
+  end
+
+  defp service_file(path, id) do
+    %{
+      "path" => path,
+      "size" => 1_000_000_000 + id,
+      "id" => id,
+      "overallBitrate" => 5_000_000,
+      "dateAdded" => "2026-01-01T00:00:00Z"
+    }
+  end
+end

--- a/test/reencodarr/sync_test.exs
+++ b/test/reencodarr/sync_test.exs
@@ -296,7 +296,7 @@ defmodule Reencodarr.SyncTest do
       }
 
       capture_log(fn ->
-        assert {:ok, {:ok, video}} = Sync.upsert_video_from_service_file(file, :sonarr)
+        assert {:ok, video} = Sync.upsert_video_from_service_file(file, :sonarr)
         assert video.path == file["path"]
         assert video.bitrate == 4_000_000
         assert video.service_type == :sonarr
@@ -323,7 +323,7 @@ defmodule Reencodarr.SyncTest do
       }
 
       capture_log(fn ->
-        assert {:ok, {:ok, video}} = Sync.upsert_video_from_service_file(file, :radarr)
+        assert {:ok, video} = Sync.upsert_video_from_service_file(file, :radarr)
         assert video.service_type == :radarr
         assert video.size == 4_000_000_000
       end)
@@ -347,9 +347,35 @@ defmodule Reencodarr.SyncTest do
       }
 
       capture_log(fn ->
-        assert {:ok, {:ok, video}} = Sync.upsert_video_from_service_file(file, :sonarr)
+        assert {:ok, video} = Sync.upsert_video_from_service_file(file, :sonarr)
         # Zero bitrate is stored as nil and triggers needs_analysis
         assert video.state == :needs_analysis
+      end)
+    end
+
+    test "returns upsert errors directly instead of wrapping them", %{library: _library} do
+      unique_id = System.unique_integer([:positive])
+
+      file = %{
+        "path" => "/test/service/invalid_#{unique_id}.mkv",
+        "size" => nil,
+        "id" => "svc_invalid_#{unique_id}",
+        "overallBitrate" => 4_000_000,
+        "dateAdded" => "2024-01-01T00:00:00Z",
+        "mediaInfo" => %{
+          "audioCodec" => "AAC",
+          "videoCodec" => "H.264",
+          "width" => 1280,
+          "height" => 720,
+          "audioLanguages" => ["eng"]
+        }
+      }
+
+      capture_log(fn ->
+        assert {:error, %Ecto.Changeset{} = changeset} =
+                 Sync.upsert_video_from_service_file(file, :sonarr)
+
+        assert {"can't be blank", _} = changeset.errors[:size]
       end)
     end
   end


### PR DESCRIPTION
## Summary
- add a single in-process DbWriter to serialize runtime SQLite mutations
- route runtime write-heavy paths through the writer and simplify webhook processing
- reduce pool size and busy timeout defaults, and add focused DbWriter tests

## Validation
- nix develop -c mix compile
- nix develop -c mix test test/reencodarr/db_writer_test.exs test/reencodarr/media/video_upsert_test.exs test/reencodarr/core/retry_test.exs